### PR TITLE
fix: 修复以`.`结尾的章节下载时找不到目录的问题

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -26,6 +26,8 @@ pub fn filename_filter(s: &str) -> String {
         })
         .collect::<String>()
         .trim()
+        .trim_end_matches('.')
+        .trim()
         .to_string()
 }
 


### PR DESCRIPTION
解决这个issue #69